### PR TITLE
spearmint: Fix crash due to NULL flare or projection shader

### DIFF
--- a/code/renderergl1/tr_shader.c
+++ b/code/renderergl1/tr_shader.c
@@ -4629,12 +4629,7 @@ static void CreateInternalShaders( void ) {
 static void CreateExternalShaders( void ) {
 	tr.projectionShadowShader = R_FindShader( "projectionShadow", LIGHTMAP_NONE, MIP_RAW_IMAGE );
 	tr.flareShader = R_FindShader( "flareShader", LIGHTMAP_NONE, MIP_RAW_IMAGE );
-
-	if ( !tr.sunShaderName[0] ) {
-		Q_strncpyz( tr.sunShaderName, "sun", sizeof ( tr.sunShaderName ) );
-	}
-
-	tr.sunShader = R_FindShader( tr.sunShaderName, LIGHTMAP_NONE, MIP_RAW_IMAGE );
+	tr.sunShader = NULL;
 }
 
 /*
@@ -4650,6 +4645,8 @@ void R_InitShaders( void ) {
 	CreateInternalShaders();
 
 	ScanAndLoadShaderFiles();
+
+	CreateExternalShaders();
 }
 
 /*
@@ -4658,5 +4655,9 @@ R_InitExternalShaders
 ==================
 */
 void R_InitExternalShaders( void ) {
-	CreateExternalShaders();
+	if ( !tr.sunShaderName[0] ) {
+		Q_strncpyz( tr.sunShaderName, "sun", sizeof ( tr.sunShaderName ) );
+	}
+
+	tr.sunShader = R_FindShader( tr.sunShaderName, LIGHTMAP_NONE, MIP_RAW_IMAGE );
 }

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -5583,12 +5583,7 @@ static void CreateInternalShaders( void ) {
 static void CreateExternalShaders( void ) {
 	tr.projectionShadowShader = R_FindShader( "projectionShadow", LIGHTMAP_NONE, MIP_RAW_IMAGE );
 	tr.flareShader = R_FindShader( "flareShader", LIGHTMAP_NONE, MIP_RAW_IMAGE );
-
-	if ( !tr.sunShaderName[0] ) {
-		Q_strncpyz( tr.sunShaderName, "sun", sizeof ( tr.sunShaderName ) );
-	}
-
-	tr.sunShader = R_FindShader( tr.sunShaderName, LIGHTMAP_NONE, MIP_RAW_IMAGE );
+	tr.sunShader = NULL;
 
 	tr.sunFlareShader = R_FindShader( "gfx/2d/sunflare", LIGHTMAP_NONE, MIP_RAW_IMAGE );
 
@@ -5624,6 +5619,8 @@ void R_InitShaders( void ) {
 	CreateInternalShaders();
 
 	ScanAndLoadShaderFiles();
+
+	CreateExternalShaders();
 }
 
 /*
@@ -5632,5 +5629,9 @@ R_InitExternalShaders
 ==================
 */
 void R_InitExternalShaders( void ) {
-	CreateExternalShaders();
+	if ( !tr.sunShaderName[0] ) {
+		Q_strncpyz( tr.sunShaderName, "sun", sizeof ( tr.sunShaderName ) );
+	}
+
+	tr.sunShader = R_FindShader( tr.sunShaderName, LIGHTMAP_NONE, MIP_RAW_IMAGE );
 }


### PR DESCRIPTION
Flare shader and projection shadow shader pointers were only set if a
map was loaded.

r_flares 2/3 adds flares for dlights and crashes in Team Arena single
player menu when displaying player models for tournament gametype. If
a map was loaded and then quit to menu, it does not crash. Q3/TA setup
player menu does not crash due to flares coincidentally being clipped
by refdef projection matrix.

If menu drew a model with RF_SHADOW_PLANE and cg_shadows 3, it would
presumably crash due to NULL projection shadow shader.

Reported by Tobias Kuehnhammer.